### PR TITLE
Update to use assert_throws_* functions for mozilla tests

### DIFF
--- a/tests/wpt/manifestupdate.py
+++ b/tests/wpt/manifestupdate.py
@@ -166,10 +166,8 @@ def diff_manifests(logger, manifest_path, old_manifest, new_manifest):
     if clean:
         # Manifest currently has some list vs tuple inconsistencies that break
         # a simple equality comparison.
-        new_paths = {(key, value[0], value[1])
-                     for (key, value) in iteritems(new_manifest.to_json()["paths"])}
-        old_paths = {(key, value[0], value[1])
-                     for (key, value) in iteritems(old_manifest.to_json()["paths"])}
+        old_paths = old_manifest.to_json()['items']
+        new_paths = new_manifest.to_json()['items']
         if old_paths != new_paths:
             logger.warning("Manifest %s contains correct tests but file hashes changed." % manifest_path)  # noqa
             clean = False

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11028,7 +11028,7 @@
       []
      ],
      "http-cache.js": [
-      "34aaacf536f31e4d9ae003cb0891ede965201f08",
+      "e418f928839aec5f093819d97afda38c33d503eb",
       []
      ],
      "iframe_contentDocument_inner.html": [
@@ -12066,7 +12066,7 @@
      ]
     },
     "idl-BluetoothUUID.html": [
-     "27f8f846384687e2b7453f80f7ae325b14233d93",
+     "445cafe07edeaf13663af653cabb40ffe365f3e9",
      [
       null,
       {}
@@ -13134,14 +13134,14 @@
      ]
     ],
     "activation.html": [
-     "abc1f58275c1a87e04aef221d337a4bd0dbf0f35",
+     "c5f556d14578c415114c435f8b1245fd0168ceba",
      [
       null,
       {}
      ]
     ],
     "adopted_node_is_same_origin_domain.html": [
-     "81de5b389c922067c61effe03208ea740ba8e067",
+     "f050835771e841026c5132938a6239eb75a47e1b",
      [
       null,
       {}
@@ -13249,7 +13249,7 @@
     ],
     "cross-origin-objects": {
      "cross-origin-objects.html": [
-      "d7b0e0da1acfe773a19301e8bdebeeee6539fb5e",
+      "2ad24df66cfa8d2571c1ab25a2dd2dfcb2c1ae4e",
       [
        null,
        {
@@ -13462,7 +13462,7 @@
      ]
     ],
     "element_attribute.html": [
-     "87eff09bf542402fadc577bccce6e0fa67737dcf",
+     "3ec766e133fea343ac645619a500c46e0e4af64c",
      [
       null,
       {}
@@ -13877,7 +13877,7 @@
      ]
     ],
     "invalid-this.html": [
-     "bc1e350522670523144a5dc8a9ad4e0398078301",
+     "2dcc7eeae58b33515417de4e92935e80fac5df62",
      [
       null,
       {}
@@ -14252,7 +14252,7 @@
      ]
     },
     "sequence-hole.html": [
-     "0021769859417ffeb4d656f7130370b628bfac7d",
+     "f56b006038956faf31287c2e336fb0f02123d550",
      [
       null,
       {}
@@ -14391,7 +14391,7 @@
      ]
     ],
     "union.html": [
-     "dec25d03b8e46791c8044c67bca93036c3e8bdeb",
+     "89d28fbcbc37060e30827cabcce7adc0bfaf9688",
      [
       null,
       {}
@@ -14500,7 +14500,7 @@
      ]
     ],
     "window-postmessage-sameorigin.html": [
-     "a3ec80929b784c6d5c766fe4cf9d99996cb8850b",
+     "6a1d00fd1c37fcf1492ecb48a02fe358ac2cbacf",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/bluetooth/idl-BluetoothUUID.html
+++ b/tests/wpt/mozilla/tests/bluetooth/idl-BluetoothUUID.html
@@ -83,23 +83,23 @@ test(() => {
 
 test(() => {
   let all_caps_uuid = '1A2B3C4D-5E6F-7A8B-9C0D-1E2F3A4B5C6D';
-  assert_throws(new TypeError(), () => BluetoothUUID.getService(all_caps_uuid));
-  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(all_caps_uuid));
-  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(all_caps_uuid));
+  assert_throws_js(TypeError, () => BluetoothUUID.getService(all_caps_uuid));
+  assert_throws_js(TypeError, () => BluetoothUUID.getCharacteristic(all_caps_uuid));
+  assert_throws_js(TypeError, () => BluetoothUUID.getDescriptor(all_caps_uuid));
 }, 'A UUID String with uppercase letters is an invalid UUID.');
 
 test(() => {
   let string_alias = 'deadbeef';
-  assert_throws(new TypeError(), () => BluetoothUUID.getService(string_alias));
-  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(string_alias));
-  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(string_alias));
+  assert_throws_js(TypeError, () => BluetoothUUID.getService(string_alias));
+  assert_throws_js(TypeError, () => BluetoothUUID.getCharacteristic(string_alias));
+  assert_throws_js(TypeError, () => BluetoothUUID.getDescriptor(string_alias));
 }, 'A 32bit *String* alias is invalid.');
 
 test(() => {
   let invalid_character_uuid = '0000000g-0000-1000-8000-00805f9b34fb';
-  assert_throws(new TypeError(), () => BluetoothUUID.getService(invalid_character_uuid));
-  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(invalid_character_uuid));
-  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(invalid_character_uuid));
+  assert_throws_js(TypeError, () => BluetoothUUID.getService(invalid_character_uuid));
+  assert_throws_js(TypeError, () => BluetoothUUID.getCharacteristic(invalid_character_uuid));
+  assert_throws_js(TypeError, () => BluetoothUUID.getDescriptor(invalid_character_uuid));
 }, 'A UUID with invalid characters is an invalid UUID.');
 
 test(() => {
@@ -112,31 +112,31 @@ test(() => {
 }, 'A valid UUID from a name.');
 
 test(() => {
-  assert_throws(new TypeError(), () => {
+  assert_throws_js(TypeError, () => {
     BluetoothUUID.getService(aerobic_heart_rate_lower_limit.name);
   });
-  assert_throws(new TypeError(), () => {
+  assert_throws_js(TypeError, () => {
     BluetoothUUID.getService(characteristic_extended_properties.name);
   });
-  assert_throws(new TypeError(), () => {
+  assert_throws_js(TypeError, () => {
     BluetoothUUID.getCharacteristic(alert_notification.name);
   });
-  assert_throws(new TypeError(), () => {
+  assert_throws_js(TypeError, () => {
     BluetoothUUID.getCharacteristic(characteristic_extended_properties.name);
   });
-  assert_throws(new TypeError(), () => {
+  assert_throws_js(TypeError, () => {
     BluetoothUUID.getDescriptor(alert_notification.name);
   });
-  assert_throws(new TypeError(), () => {
+  assert_throws_js(TypeError, () => {
     BluetoothUUID.getDescriptor(aerobic_heart_rate_lower_limit.name);
   });
 }, 'Make sure attributes don\'t share a map');
 
 test(() => {
   let wrong_name = 'wrong_name';
-  assert_throws(new TypeError(), () => BluetoothUUID.getService(wrong_name));
-  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(wrong_name));
-  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(wrong_name));
+  assert_throws_js(TypeError, () => BluetoothUUID.getService(wrong_name));
+  assert_throws_js(TypeError, () => BluetoothUUID.getCharacteristic(wrong_name));
+  assert_throws_js(TypeError, () => BluetoothUUID.getDescriptor(wrong_name));
 }, 'Invalid Descriptor name');
 
 test(() => {
@@ -144,35 +144,35 @@ test(() => {
   let array = [];
   let func = () => {};
   // cannonicalUUID
-  assert_throws(new TypeError, () => BluetoothUUID.canonicalUUID(object));
+  assert_throws_js(new TypeError, () => BluetoothUUID.canonicalUUID(object));
   // [] converts to '', which converts to 0 before the range check.
   assert_equals(BluetoothUUID.canonicalUUID(array), base_uuid);
-  assert_throws(new TypeError, () => BluetoothUUID.canonicalUUID(func));
-  assert_throws(new TypeError, () => BluetoothUUID.canonicalUUID(undefined));
+  assert_throws_js(new TypeError, () => BluetoothUUID.canonicalUUID(func));
+  assert_throws_js(new TypeError, () => BluetoothUUID.canonicalUUID(undefined));
   assert_equals(BluetoothUUID.canonicalUUID(null), base_uuid);
   assert_equals(BluetoothUUID.canonicalUUID(false), base_uuid);
   assert_equals(BluetoothUUID.canonicalUUID(true), BluetoothUUID.canonicalUUID(1));
-  assert_throws(new TypeError, () => BluetoothUUID.canonicalUUID(NaN));
+  assert_throws_js(new TypeError, () => BluetoothUUID.canonicalUUID(NaN));
   // getService
-  assert_throws(new TypeError(), () => BluetoothUUID.getService(object));
-  assert_throws(new TypeError(), () => BluetoothUUID.getService(array));
-  assert_throws(new TypeError(), () => BluetoothUUID.getService(func));
-  assert_throws(new TypeError(), () => BluetoothUUID.getService(undefined));
-  assert_throws(new TypeError(), () => BluetoothUUID.getService(null));
-  assert_throws(new TypeError(), () => BluetoothUUID.getService(false));
+  assert_throws_js(TypeError, () => BluetoothUUID.getService(object));
+  assert_throws_js(TypeError, () => BluetoothUUID.getService(array));
+  assert_throws_js(TypeError, () => BluetoothUUID.getService(func));
+  assert_throws_js(TypeError, () => BluetoothUUID.getService(undefined));
+  assert_throws_js(TypeError, () => BluetoothUUID.getService(null));
+  assert_throws_js(TypeError, () => BluetoothUUID.getService(false));
   // getCharacteristic
-  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(object));
-  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(array));
-  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(func));
-  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(undefined));
-  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(null));
-  assert_throws(new TypeError(), () => BluetoothUUID.getCharacteristic(false));
+  assert_throws_js(TypeError, () => BluetoothUUID.getCharacteristic(object));
+  assert_throws_js(TypeError, () => BluetoothUUID.getCharacteristic(array));
+  assert_throws_js(TypeError, () => BluetoothUUID.getCharacteristic(func));
+  assert_throws_js(TypeError, () => BluetoothUUID.getCharacteristic(undefined));
+  assert_throws_js(TypeError, () => BluetoothUUID.getCharacteristic(null));
+  assert_throws_js(TypeError, () => BluetoothUUID.getCharacteristic(false));
   // getDescriptor
-  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(object));
-  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(array));
-  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(func));
-  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(undefined));
-  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(null));
-  assert_throws(new TypeError(), () => BluetoothUUID.getDescriptor(false));
+  assert_throws_js(TypeError, () => BluetoothUUID.getDescriptor(object));
+  assert_throws_js(TypeError, () => BluetoothUUID.getDescriptor(array));
+  assert_throws_js(TypeError, () => BluetoothUUID.getDescriptor(func));
+  assert_throws_js(TypeError, () => BluetoothUUID.getDescriptor(undefined));
+  assert_throws_js(TypeError, () => BluetoothUUID.getDescriptor(null));
+  assert_throws_js(TypeError, () => BluetoothUUID.getDescriptor(false));
 }, 'Non-number and non-strings');
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/activation.html
+++ b/tests/wpt/mozilla/tests/mozilla/activation.html
@@ -42,7 +42,7 @@
       "Activate input");
 
     test(function () {
-      assert_throws("NotSupportedError", function () {
+      assert_throws_dom("NotSupportedError", function () {
         var foo = document.getElementById("foo");
         foo.enterFormalActivationState();
       });

--- a/tests/wpt/mozilla/tests/mozilla/adopted_node_is_same_origin_domain.html
+++ b/tests/wpt/mozilla/tests/mozilla/adopted_node_is_same_origin_domain.html
@@ -22,7 +22,7 @@ async_test(function(t) {
     // We can still access the adopted node, since it is still same-origin-domain,
     // but accessing the unadopted node throws a security exception.
     assert_equals(nodeToAdopt.ownerDocument, document);
-    assert_throws(null, function() { nodeToLeaveUnadopted.ownerDocument; });
+    assert_throws_exactly(null, function() { nodeToLeaveUnadopted.ownerDocument; });
     t.done();
   });
   document.body.appendChild(iframe);

--- a/tests/wpt/mozilla/tests/mozilla/cross-origin-objects/cross-origin-objects.html
+++ b/tests/wpt/mozilla/tests/mozilla/cross-origin-objects/cross-origin-objects.html
@@ -83,14 +83,14 @@ async_test(function(t) {
           Object.getOwnPropertyDescriptor(C, prop); // Shouldn't throw.
           assert_true(Object.prototype.hasOwnProperty.call(C, prop), "hasOwnProperty for " + String(prop));
         } else {
-          assert_throws("SecurityError", function() { C[prop]; }, "Should throw when accessing " + String(prop) + " on Window");
-          assert_throws("SecurityError", function() { Object.getOwnPropertyDescriptor(C, prop); },
+          assert_throws_dom("SecurityError", function() { C[prop]; }, "Should throw when accessing " + String(prop) + " on Window");
+          assert_throws_dom("SecurityError", function() { Object.getOwnPropertyDescriptor(C, prop); },
                         "Should throw when accessing property descriptor for " + prop + " on Window");
-          assert_throws("SecurityError", function() { Object.prototype.hasOwnProperty.call(C, prop); },
+          assert_throws_dom("SecurityError", function() { Object.prototype.hasOwnProperty.call(C, prop); },
                         "Should throw when invoking hasOwnProperty for " + prop + " on Window");
         }
         if (prop != 'location')
-          assert_throws("SecurityError", function() { C[prop] = undefined; }, "Should throw when writing to " + prop + " on Window");
+          assert_throws_dom("SecurityError", function() { C[prop] = undefined; }, "Should throw when writing to " + prop + " on Window");
       }
       for (var prop in location) {
         if (prop == 'replace') {
@@ -99,14 +99,14 @@ async_test(function(t) {
           assert_true(Object.prototype.hasOwnProperty.call(C.location, prop), "hasOwnProperty for " + prop);
         }
         else {
-          assert_throws("SecurityError", function() { C[prop]; }, "Should throw when accessing " + prop + " on Location");
-          assert_throws("SecurityError", function() { Object.getOwnPropertyDescriptor(C, prop); },
+          assert_throws_dom("SecurityError", function() { C[prop]; }, "Should throw when accessing " + prop + " on Location");
+          assert_throws_dom("SecurityError", function() { Object.getOwnPropertyDescriptor(C, prop); },
                         "Should throw when accessing property descriptor for " + prop + " on Location");
-          assert_throws("SecurityError", function() { Object.prototype.hasOwnProperty.call(C, prop); },
+          assert_throws_dom("SecurityError", function() { Object.prototype.hasOwnProperty.call(C, prop); },
                         "Should throw when invoking hasOwnProperty for " + prop + " on Location");
         }
         if (prop != 'href')
-          assert_throws("SecurityError", function() { C[prop] = undefined; }, "Should throw when writing to " + prop + " on Location");
+          assert_throws_dom("SecurityError", function() { C[prop] = undefined; }, "Should throw when writing to " + prop + " on Location");
       }
       t.done();
     }

--- a/tests/wpt/mozilla/tests/mozilla/element_attribute.html
+++ b/tests/wpt/mozilla/tests/mozilla/element_attribute.html
@@ -52,13 +52,13 @@
     });
 
     test(function() {
-      assert_throws("NamespaceError", function () {
+      assert_throws_dom("NamespaceError", function () {
         element.setAttributeNS("http://example.com", "xmlns", "foo");
       });
-      assert_throws("NamespaceError", function () {
+      assert_throws_dom("NamespaceError", function () {
         element.setAttributeNS("http://www.w3.org/2000/xmlns/", "attr", "value");
       });
-      assert_throws("NamespaceError", function () {
+      assert_throws_dom("NamespaceError", function () {
         element.setAttributeNS("http://www.w3.org/2000/xmlns/", "prefix:attr", "value");
       });
     });

--- a/tests/wpt/mozilla/tests/mozilla/invalid-this.html
+++ b/tests/wpt/mozilla/tests/mozilla/invalid-this.html
@@ -5,9 +5,9 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 test(function() {
-  assert_throws(new TypeError(), function() { window.atob.call("", localStorage); })
-  assert_throws(new TypeError(), function() { window.removeEventListener.call("", ""); })
-  assert_throws(new TypeError(), function() { window.alert.call(""); })
-  assert_throws(new TypeError(), function() { window.moveTo.call(128); })
+  assert_throws_js(TypeError, function() { window.atob.call("", localStorage); })
+  assert_throws_js(TypeError, function() { window.removeEventListener.call("", ""); })
+  assert_throws_js(TypeError, function() { window.alert.call(""); })
+  assert_throws_js(TypeError, function() { window.moveTo.call(128); })
 })
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/resources/http-cache.js
+++ b/tests/wpt/mozilla/tests/mozilla/resources/http-cache.js
@@ -186,7 +186,7 @@ function make_test(raw_requests) {
               }
             }, function(reason) {
               if ("expected_type" in config && config.expected_type === "error") {
-                assert_throws(new TypeError(), function() { throw reason; });
+                assert_throws_js(TypeError, function() { throw reason; });
               } else {
                 throw reason;
               }

--- a/tests/wpt/mozilla/tests/mozilla/sequence-hole.html
+++ b/tests/wpt/mozilla/tests/mozilla/sequence-hole.html
@@ -8,20 +8,20 @@ test(function() {
   var t = new TestBinding;
   t.passSequence([1,, 3]);
   t.passStringSequence(["camembert",, "comté"]);
-  assert_throws(new TypeError, function () { t.passInterfaceSequence([new Blob,, new Blob]) });
+  assert_throws_js(TypeError, function () { t.passInterfaceSequence([new Blob,, new Blob]) });
 }, "Sequences with holes are correctly handled");
 
 test(function() {
   var test_error = { name: "test" };
   Object.defineProperty(Array.prototype, 1, { get: function() { throw test_error; } });
   var t = new TestBinding;
-  assert_throws(test_error, function() {
+  assert_throws_exactly(test_error, function() {
     t.passSequence([1,, 3]);
   });
-  assert_throws(test_error, function() {
+  assert_throws_exactly(test_error, function() {
     t.passStringSequence(["camembert",, "comté"]);
   });
-  assert_throws(test_error, function() {
+  assert_throws_exactly(test_error, function() {
     t.passInterfaceSequence([new Blob,, new Blob]);
   });
 }, "Sequences with holes and a getter on the prototype are correctly handled");

--- a/tests/wpt/mozilla/tests/mozilla/union.html
+++ b/tests/wpt/mozilla/tests/mozilla/union.html
@@ -14,13 +14,13 @@ test(function() {
   var opt = document.createElement('option');
   sel.add(opt);
   sel.add(optgroup);
-  assert_throws("NotFoundError", function() { sel.add(opt, div); });
-  assert_throws("NotFoundError", function() { sel.add(optgroup, div); });
+  assert_throws_dom("NotFoundError", function() { sel.add(opt, div); });
+  assert_throws_dom("NotFoundError", function() { sel.add(optgroup, div); });
   sel.add(opt, div2);
   sel.add(optgroup, div2);
   sel.add(opt, 5);
   sel.add(optgroup, 5);
-  assert_throws(new TypeError(), function() { sel.add(div) });
+  assert_throws_js(TypeError, function() { sel.add(div) });
   sel.add(optgroup, function() {})
 });
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/window-postmessage-sameorigin.html
+++ b/tests/wpt/mozilla/tests/mozilla/window-postmessage-sameorigin.html
@@ -9,10 +9,18 @@ setup({
   explicit_done: true
 });
 
-function expect_error(error, message, origin, description) {
+function expect_error_js(error, message, origin, description) {
   return function(setlistener, removelistener, type) {
     test(function(t) {
-      assert_throws(error, function() { postMessage(message, origin) });
+      assert_throws_js(error, function() { postMessage(message, origin) });
+    }, description + ' (' + type + ')');
+  }
+}
+
+function expect_error_dom(error, message, origin, description) {
+  return function(setlistener, removelistener, type) {
+    test(function(t) {
+      assert_throws_dom(error, function() { postMessage(message, origin) });
     }, description + ' (' + type + ')');
   }
 }
@@ -48,8 +56,8 @@ var base_tests = [
   function() { return expect_message('basic', '/', 'same origin, cloneable string message') },
   function() { return expect_message('basic', HTTP_ORIGIN, 'explicit same origin, cloneable string message') },
   function() { return expect_no_message('basic', HTTPS_ORIGIN, 'explicit cross origin, cloneable string message') },
-  function() { return expect_error(new SyntaxError(), 'basic', 'not-a-url', 'explicit invalid url, cloneable string message') },
-  function() { return expect_error('DATA_CLONE_ERR', window, '*', 'any origin, non-cloneable message') },
+  function() { return expect_error_js(SyntaxError, 'basic', 'not-a-url', 'explicit invalid url, cloneable string message') },
+  function() { return expect_error_dom('DATA_CLONE_ERR', window, '*', 'any origin, non-cloneable message') },
 ];
 
 var tests = [];


### PR DESCRIPTION
This should fix the not defined `assert_throws` issue at https://github.com/servo/servo/pull/25764#issuecomment-586278492.

https://github.com/servo/servo/pull/25764#issuecomment-586277731 is caused by the **Manifest path trie RFC** https://github.com/web-platform-tests/rfcs/pull/40 .


---
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes
